### PR TITLE
Update owncloud.ldif

### DIFF
--- a/owncloud.ldif
+++ b/owncloud.ldif
@@ -19,17 +19,17 @@
 dn: cn=owncloud,cn=schema,cn=config
 objectClass: olcSchemaConfig
 cn: owncloud
-olcAttributeTypes: ( 1.3.6.1.4.1.39430.1.1.1 
- NAME 'ownCloudQuota' 
- DESC 'User Quota (e.g. 2 GB)' 
- EQUALITY caseExactMatch 
- SUBSTR caseIgnoreSubstringsMatch 
- SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 
+olcAttributeTypes: {0}( 1.3.6.1.4.1.39430.1.1.1
+ NAME 'ownCloudQuota'
+ DESC 'User Quota (e.g. 15 GB)'
+ EQUALITY caseExactMatch
+ SUBSTR caseIgnoreSubstringsMatch
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
  SINGLE-VALUE )
-olcObjectClasses: ( 1.3.6.1.4.1.39430.1.2.1 
- NAME 'ownCloud' 
- DESC 'ownCloud LDAP Schema' 
- AUXILIARY 
- MAY ( ownCloudQuota ) )
+olcObjectClasses: {0}( 1.3.6.1.4.1.39430.1.2.1
+ NAME 'ownCloud'
+ DESC 'ownCloud LDAP Schema'
+ AUXILIARY
+ MAY ownCloudQuota )
 
 


### PR DESCRIPTION
For inexplicable reasons, I was not able to import the ldif file stored here. I always got the message: "invalid syntax". That's why I used [a script](https://gist.github.com/steve-todorov/44d9a54546468ea75e84ead5cd1e22b8) to convert the schema file into an ldif file and get this working result.

I am using the following LDAP version: bionic/main amd64 slapd amd64 2.4.45+dfsg-1ubuntu1